### PR TITLE
Changed coins in StakePool. Changed pool balance storage logics

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -8,5 +8,13 @@ staking_admin = "0xee89c702cc7237f637be750dd110460ec8b2521e7cb69ec2c7d05074e469d
 
 [dependencies.AptosFramework]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = '555b33b4d0cc7baa19ddca4f7f0873907691e25b'
+rev = '985f19d40457a5f09f2d741b1feca6bf7ba1f8a6'
 subdir = 'aptos-move/framework/aptos-framework'
+
+[dependencies.Liquidswap]
+git = 'https://github.com/pontem-network/liquidswap.git'
+rev = 'v0.4.0'
+
+[dependencies.TestCoins]
+git = 'https://github.com/pontem-network/test-coins.git'
+rev = 'v0.1.2'

--- a/tests/liq_stake_tests.move
+++ b/tests/liq_stake_tests.move
@@ -3,9 +3,14 @@ module staking_admin::staking_tests {
     use std::signer;
 
     use aptos_framework::account;
-    use aptos_framework::coin;
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::genesis;
+    use liquidswap::curves::Uncorrelated;
+    use liquidswap::liquidity_pool;
+    use liquidswap_lp::lp_coin::LP;
+    use test_coins::coins::{Self, USDT, BTC};
+    use test_helpers::test_pool;
 
-    use coin_creator::liq::{Self, LIQ};
     use staking_admin::staking;
 
     public fun create_account(account_address: address): (signer, address) {
@@ -15,97 +20,121 @@ module staking_admin::staking_tests {
         (new_acc, new_addr)
     }
 
-    public fun create_account_with_liq_coins(
-        account_address: address,
-        liq_amount: u64,
-        coin_creator_acc: &signer
-    ): (signer, address) {
-        let (new_acc, new_addr) = create_account(account_address);
-        let coins = liq::mint(coin_creator_acc, liq_amount);
+    public fun mint_9000_lp_coins(): Coin<LP<BTC, USDT, Uncorrelated>> {
+        let (coins_owner_acc, coins_owner_addr) = create_account(@test_coins);
+        let (lp_owner, _) = create_account(@0x42);
 
-        coin::register<LIQ>(&new_acc);
-        coin::deposit<LIQ>(new_addr, coins);
+        coins::register_coins(&coins_owner_acc);
 
-        (new_acc, new_addr)
+        genesis::setup();
+        test_pool::initialize_liquidity_pool();
+
+        // create a new pool in Liquidswap
+        liquidity_pool::register<BTC, USDT, Uncorrelated>(&lp_owner);
+
+        // mint coins for LP
+        coin::register<BTC>(&coins_owner_acc);
+        coin::register<USDT>(&coins_owner_acc);
+        coins::mint_coin<BTC>(&coins_owner_acc, coins_owner_addr, 10000);
+        coins::mint_coin<USDT>(&coins_owner_acc, coins_owner_addr, 10000);
+
+        let coin_btc = coin::withdraw<BTC>(&coins_owner_acc, 10000);
+        let coin_usdt = coin::withdraw<USDT>(&coins_owner_acc, 10000);
+
+        // get LP coins
+        let amount = test_pool::mint_liquidity<BTC, USDT, Uncorrelated>(&lp_owner, coin_btc, coin_usdt);
+        coin::withdraw<LP<BTC, USDT, Uncorrelated>>(&lp_owner, amount)
     }
 
-    public fun create_coin(creator_addr: address): signer {
-        let (coin_creator_acc, _) = create_account(creator_addr);
+    public fun create_account_with_lp_coins(
+        account_address: address,
+        coins: Coin<LP<BTC, USDT, Uncorrelated>>
+    ): (signer, address) {
+        let (new_acc, new_addr) = create_account(account_address);
 
-        liq::initialize(&coin_creator_acc);
-        coin_creator_acc
+        coin::register<LP<BTC, USDT, Uncorrelated>>(&new_acc);
+        coin::deposit<LP<BTC, USDT, Uncorrelated>>(new_addr, coins);
+
+        (new_acc, new_addr)
     }
 
     #[test]
     public fun test_stake_and_unstake() {
         let (staking_admin_acc, _) = create_account(@staking_admin);
 
-        // create coin
-        let coin_creator_acc = create_coin(@coin_creator);
+        // create lp coins
+        let lp_coin = mint_9000_lp_coins();
+        let lp_coin_half = coin::extract(&mut lp_coin, 4500);
 
-        // mint coins for alice and bob
+        // create alice and bob with LP coins
         let (alice_acc, alice_addr) =
-            create_account_with_liq_coins(@0x10, 150, &coin_creator_acc);
+            create_account_with_lp_coins(@0x10, lp_coin);
         let (bob_acc, bob_addr) =
-            create_account_with_liq_coins(@0x11, 40, &coin_creator_acc);
+            create_account_with_lp_coins(@0x11, lp_coin_half);
 
         // initialize staking pool
-        staking::initialize<LIQ>(&staking_admin_acc);
+        staking::initialize<BTC, USDT, Uncorrelated>(&staking_admin_acc);
 
         // check empty balances
-        assert!(staking::get_total_stake<LIQ>() == 0, 1);
-        assert!(staking::get_user_stake<LIQ>(alice_addr) == 0, 1);
-        assert!(staking::get_user_stake<LIQ>(bob_addr) == 0, 1);
+        assert!(staking::get_total_stake<BTC, USDT, Uncorrelated>() == 0, 1);
+        assert!(staking::get_user_stake<BTC, USDT, Uncorrelated>(alice_addr) == 0, 1);
+        assert!(staking::get_user_stake<BTC, USDT, Uncorrelated>(bob_addr) == 0, 1);
 
         // stake from alice
-        let coins = coin::withdraw<LIQ>(&alice_acc, 33);
-        staking::stake<LIQ>(&alice_acc, coins);
-        assert!(coin::balance<LIQ>(alice_addr) == 117, 1);
-        assert!(staking::get_user_stake<LIQ>(alice_addr) == 33, 1);
-        assert!(staking::get_total_stake<LIQ>() == 33, 1);
+        let coins =
+            coin::withdraw<LP<BTC, USDT, Uncorrelated>>(&alice_acc, 500);
+        staking::stake<BTC, USDT, Uncorrelated>(&alice_acc, coins);
+        assert!(coin::balance<LP<BTC, USDT, Uncorrelated>>(alice_addr) == 4000, 1);
+        assert!(staking::get_user_stake<BTC, USDT, Uncorrelated>(alice_addr) == 500, 1);
+        assert!(staking::get_total_stake<BTC, USDT, Uncorrelated>() == 500, 1);
 
         // stake from bob
-        let coins = coin::withdraw<LIQ>(&bob_acc, 40);
-        staking::stake<LIQ>(&bob_acc, coins);
-        assert!(coin::balance<LIQ>(bob_addr) == 0, 1);
-        assert!(staking::get_user_stake<LIQ>(bob_addr) == 40, 1);
-        assert!(staking::get_total_stake<LIQ>() == 73, 1);
+        let coins =
+            coin::withdraw<LP<BTC, USDT, Uncorrelated>>(&bob_acc, 4500);
+        staking::stake<BTC, USDT, Uncorrelated>(&bob_acc, coins);
+        assert!(coin::balance<LP<BTC, USDT, Uncorrelated>>(bob_addr) == 0, 1);
+        assert!(staking::get_user_stake<BTC, USDT, Uncorrelated>(bob_addr) == 4500, 1);
+        assert!(staking::get_total_stake<BTC, USDT, Uncorrelated>() == 5000, 1);
 
         // stake more from alice
-        let coins = coin::withdraw<LIQ>(&alice_acc, 33);
-        staking::stake<LIQ>(&alice_acc, coins);
-        assert!(coin::balance<LIQ>(alice_addr) == 84, 1);
-        assert!(staking::get_user_stake<LIQ>(alice_addr) == 66, 1);
-        assert!(staking::get_total_stake<LIQ>() == 106, 1);
+        let coins =
+            coin::withdraw<LP<BTC, USDT, Uncorrelated>>(&alice_acc, 500);
+        staking::stake<BTC, USDT, Uncorrelated>(&alice_acc, coins);
+        assert!(coin::balance<LP<BTC, USDT, Uncorrelated>>(alice_addr) == 3500, 1);
+        assert!(staking::get_user_stake<BTC, USDT, Uncorrelated>(alice_addr) == 1000, 1);
+        assert!(staking::get_total_stake<BTC, USDT, Uncorrelated>() == 5500, 1);
 
         // unstake some from alice
-        let coins = staking::unstake<LIQ>(&alice_acc, 16);
-        assert!(coin::value<LIQ>(&coins) == 16, 1);
-        assert!(staking::get_user_stake<LIQ>(alice_addr) == 50, 1);
-        assert!(staking::get_total_stake<LIQ>() == 90, 1);
-        coin::deposit<LIQ>(alice_addr, coins);
+        let coins =
+            staking::unstake<BTC, USDT, Uncorrelated>(&alice_acc, 450);
+        assert!(coin::value<LP<BTC, USDT, Uncorrelated>>(&coins) == 450, 1);
+        assert!(staking::get_user_stake<BTC, USDT, Uncorrelated>(alice_addr) == 550, 1);
+        assert!(staking::get_total_stake<BTC, USDT, Uncorrelated>() == 5050, 1);
+        coin::deposit<LP<BTC, USDT, Uncorrelated>>(alice_addr, coins);
 
         // unstake all from bob
-        let coins = staking::unstake<LIQ>(&bob_acc, 40);
-        assert!(coin::value<LIQ>(&coins) == 40, 1);
-        assert!(staking::get_user_stake<LIQ>(bob_addr) == 0, 1);
-        assert!(staking::get_total_stake<LIQ>() == 50, 1);
-        coin::deposit<LIQ>(bob_addr, coins);
+        let coins =
+            staking::unstake<BTC, USDT, Uncorrelated>(&bob_acc, 4500);
+        assert!(coin::value<LP<BTC, USDT, Uncorrelated>>(&coins) == 4500, 1);
+        assert!(staking::get_user_stake<BTC, USDT, Uncorrelated>(bob_addr) == 0, 1);
+        assert!(staking::get_total_stake<BTC, USDT, Uncorrelated>() == 550, 1);
+        coin::deposit<LP<BTC, USDT, Uncorrelated>>(bob_addr, coins);
     }
 
     #[test]
     #[expected_failure(abort_code = 100 /* ERR_NO_POOL */)]
     public fun test_stake_fails_if_pool_does_not_exist() {
-        // create coin
-        let coin_creator_acc= create_coin(@coin_creator);
+        // create lp coins
+        let lp_coin = mint_9000_lp_coins();
 
-        // mint coins for alice
+        // create alice with LP coins
         let (alice_acc, _) =
-            create_account_with_liq_coins(@0x10, 150, &coin_creator_acc);
+            create_account_with_lp_coins(@0x10, lp_coin);
 
         // stake from alice
-        let coins = coin::withdraw<LIQ>(&alice_acc, 33);
-        staking::stake<LIQ>(&alice_acc, coins);
+        let coins =
+            coin::withdraw<LP<BTC, USDT, Uncorrelated>>(&alice_acc, 123);
+        staking::stake<BTC, USDT, Uncorrelated>(&alice_acc, coins);
     }
 
     #[test]
@@ -114,14 +143,15 @@ module staking_admin::staking_tests {
         let (alice_acc, alice_addr) = create_account(@0x10);
 
         // unstake from alice
-        let coins = staking::unstake<LIQ>(&alice_acc, 100);
-        coin::deposit<LIQ>(alice_addr, coins);
+        let coins =
+            staking::unstake<BTC, USDT, Uncorrelated>(&alice_acc, 100);
+        coin::deposit<LP<BTC, USDT, Uncorrelated>>(alice_addr, coins);
     }
 
     #[test]
     #[expected_failure(abort_code = 100 /* ERR_NO_POOL */)]
     public fun test_get_total_stake_fails_if_pool_does_not_exist() {
-        staking::get_total_stake<LIQ>();
+        staking::get_total_stake<BTC, USDT, Uncorrelated>();
     }
 
     #[test]
@@ -129,7 +159,7 @@ module staking_admin::staking_tests {
     public fun test_get_user_stake_fails_if_pool_does_not_exist() {
         let (_, alice_addr) = create_account(@0x10);
 
-        staking::get_user_stake<LIQ>(alice_addr);
+        staking::get_user_stake<BTC, USDT, Uncorrelated>(alice_addr);
     }
 
     #[test]
@@ -138,8 +168,8 @@ module staking_admin::staking_tests {
         let (staking_admin_acc, _) = create_account(@staking_admin);
 
         // initialize staking pool twice
-        staking::initialize<LIQ>(&staking_admin_acc);
-        staking::initialize<LIQ>(&staking_admin_acc);
+        staking::initialize<BTC, USDT, Uncorrelated>(&staking_admin_acc);
+        staking::initialize<BTC, USDT, Uncorrelated>(&staking_admin_acc);
     }
 
     #[test]
@@ -149,11 +179,12 @@ module staking_admin::staking_tests {
         let (alice_acc, alice_addr) = create_account(@0x10);
 
         // initialize staking pool
-        staking::initialize<LIQ>(&staking_admin_acc);
+        staking::initialize<BTC, USDT, Uncorrelated>(&staking_admin_acc);
 
         // unstake from alice
-        let coins = staking::unstake<LIQ>(&alice_acc, 40);
-        coin::deposit<LIQ>(alice_addr, coins);
+        let coins =
+            staking::unstake<BTC, USDT, Uncorrelated>(&alice_acc, 40);
+        coin::deposit<LP<BTC, USDT, Uncorrelated>>(alice_addr, coins);
     }
 
     #[test]
@@ -161,25 +192,27 @@ module staking_admin::staking_tests {
     public fun test_unstake_fails_if_not_enough_balance() {
         let (staking_admin_acc, _) = create_account(@staking_admin);
 
-        // create coin
-        let coin_creator_acc = create_coin(@coin_creator);
+        // create lp coins
+        let lp_coin = mint_9000_lp_coins();
 
-        // mint coins for alice
+        // create alice with LP coins
         let (alice_acc, alice_addr) =
-            create_account_with_liq_coins(@0x10, 150, &coin_creator_acc);
+            create_account_with_lp_coins(@0x10, lp_coin);
 
         // initialize staking pool
-        staking::initialize<LIQ>(&staking_admin_acc);
+        staking::initialize<BTC, USDT, Uncorrelated>(&staking_admin_acc);
 
         // stake from alice
-        let coins = coin::withdraw<LIQ>(&alice_acc, 150);
-        staking::stake<LIQ>(&alice_acc, coins);
-        assert!(coin::balance<LIQ>(alice_addr) == 0, 1);
-        assert!(staking::get_user_stake<LIQ>(alice_addr) == 150, 1);
+        let coins =
+            coin::withdraw<LP<BTC, USDT, Uncorrelated>>(&alice_acc, 9000);
+        staking::stake<BTC, USDT, Uncorrelated>(&alice_acc, coins);
+        assert!(coin::balance<LP<BTC, USDT, Uncorrelated>>(alice_addr) == 0, 1);
+        assert!(staking::get_user_stake<BTC, USDT, Uncorrelated>(alice_addr) == 9000, 1);
 
         // unstake more than staked from alice
-        let coins = staking::unstake<LIQ>(&alice_acc, 151);
-        coin::deposit<LIQ>(alice_addr, coins);
+        let coins =
+            staking::unstake<BTC, USDT, Uncorrelated>(&alice_acc, 9001);
+        coin::deposit<LP<BTC, USDT, Uncorrelated>>(alice_addr, coins);
     }
 
     #[test]
@@ -188,6 +221,6 @@ module staking_admin::staking_tests {
         let (alice_acc, _) = create_account(@0x10);
 
         // initialize staking pool
-        staking::initialize<LIQ>(&alice_acc);
+        staking::initialize<BTC, USDT, Uncorrelated>(&alice_acc);
     }
 }


### PR DESCRIPTION
- All coins in pool now stored in one place, tables instead stores user balances.
- Previously, pool accepted LIQ coins as input, now it accepts LP<X, Y, Curve> coins
- Tests adapted for LP coins